### PR TITLE
Update API endpoint

### DIFF
--- a/lib/rome2rio/connection.rb
+++ b/lib/rome2rio/connection.rb
@@ -2,7 +2,7 @@ module Rome2rio
   class Connection
     def initialize(opts = {})
       @apikey = opts[:apikey]
-      @endpoint = opts[:endpoint] || "http://partners.rome2rio.com"
+      @endpoint = opts[:endpoint] || "http://free.rome2rio.com"
     end
 
     def handle_response(response)


### PR DESCRIPTION
evaluate.rome2rio.com is expiring on Monday, 17th March
